### PR TITLE
Add hook scripts and enhanced agent status tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 AGENTS.md
 TODOs.md
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ By default the installer copies `bin/gwt` to `~/.local/bin/gwt` and writes confi
 After installation make sure `~/.local/bin` is on your `PATH`, then run:
 ```bash
 gwt help
+gwt version
 ```
+
+`gwt version` (or `gwt --version`) prints the installed release so you can confirm which build you're running.
 
 The installer automatically appends a completion snippet to your detected shell (`~/.bashrc` or `~/.zshrc`). Override the target shell with `--shell bash|zsh` or skip the change entirely with `--skip-shell-config` and add the snippet yourself later.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Optimal usage expects basic tmux familiarity—know how to detach, switch panes,
 ```bash
 git clone <repo-url>
 cd geewit
-./install.sh --agent "my-agent"
+./install.sh
 ```
 
 By default the installer copies `bin/gwt` to `~/.local/bin/gwt` and writes configuration to `~/.config/gwt/config`. Set alternative locations with `--prefix`, `--worktree-base`, or `--dir-prefix`. Re-run the installer with `--force` to overwrite an existing binary.
@@ -106,6 +106,19 @@ Generate completion scripts from the CLI:
 
 If you use `share/gwt-profile.sh` it will register the appropriate completion automatically.
 
+## Hook scripts
+You can run custom scripts automatically when creating or removing worktrees by placing executable scripts in your repository root:
+
+- `.geewit_new.sh` – runs in the right tmux pane after `gwt new` finishes setup
+- `.geewit_remove.sh` – runs in the worktree directory before `gwt remove` cleans up
+
+Scripts must be executable (`chmod +x .geewit_*.sh`). They're useful for project-specific setup like installing dependencies, starting services, or cleaning up resources.
+
+Example `.geewit_new.sh`:
+```bash
+#!/usr/bin/env bash
+npm install
+```
+
 ## Tips
-- Alias frequently used agent arguments (for continuing conversations, granting permissions, etc.) so you can pass them to `gwt` without retyping the full command each time (e.g., `alias ccdsp="claude --dangerously-skip-permissions"`).
 - You can invoke `gwt` from any of its worktrees (not just the original clone); the CLI automatically targets the primary repository for shared assets such as tmux sessions and VS Code workspace updates.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Use the built-in helper commands:
 ```bash
 gwt agent set "my-other-agent --flag"
 gwt agent show
+gwt agent status
 gwt agent clear
 ```
 Configuration lives in `~/.config/gwt/config`; edit it directly if you prefer.
@@ -50,6 +51,7 @@ Per session, override the agent pane with `gwt new feature-login --agent "my-tem
 - `gwt cleanup` – interactively prune worktrees that are already merged into main
 - `gwt from-pr 123` – spin up a worktree directly from a GitHub PR (requires `gh`)
 - `gwt merge feature-branch [base] [--keep]` – merge a feature branch into the base branch (default `main`) and automatically remove the worktree and local branch unless you pass `--keep`
+- `gwt agent status` – inspect every worktree’s agent pane (running, waiting, done, disabled)
 
 ### Merging branches with cleanup
 `gwt merge feature-branch [base]` orchestrates a fast-forward-preventing merge inside the primary worktree (usually the clone you installed from). Both the target branch and the base must be clean; the command will abort with a helpful message if either contains uncommitted changes.
@@ -70,6 +72,18 @@ Customize the location with either of the following:
 
 ## Tmux status bar
 Every session created by `gwt new` configures the tmux status bar to call `gwt tmux-status`. The right side shows the branch name, staged/modified/untracked counts, and upstream sync arrows so you can see repo state at a glance from any pane.
+
+## Agent status dashboard
+`gwt agent status` lists each worktree alongside the matching tmux session, the configured agent command, and its current state:
+
+- `waiting` – pane created and waiting for the agent wrapper to start the configured command
+- `running` – the agent command is active inside the tmux pane
+- `done` – the agent finished with exit code 0 (the pane remains for inspection)
+- `error (exit N)` – the agent finished with a non-zero exit status
+- `disabled` – no agent command is configured for the session
+- `missing` – the worktree exists but there is no tmux session (run `gwt switch <branch>` to recreate it)
+
+This mirrors the tmux naming convention (`<repo>-<branch>`) so you can quickly match a CLI entry to a live session.
 
 ## Uninstall
 Remove the binary and config:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Configuration lives in `~/.config/gwt/config`; edit it directly if you prefer.
 Per session, override the agent pane with `gwt new feature-login --agent "my-temp-agent"` or skip launching one entirely via `gwt new feature-login --no-agent`.
 
 ## Daily workflow
-- `gwt new feature-branch [base] [--agent cmd]` – create a worktree, split tmux window, start the configured agent (override per session with `--agent`), and open a git status pane; pass a base branch to seed from something other than `main`, even if that branch already has its own gwt worktree
+- `gwt new feature-branch [base] [--agent cmd] [--detach]` – create a worktree, split tmux window, start the configured agent (override per session with `--agent`), and open a git status pane; pass a base branch to seed from something other than `main`, even if that branch already has its own gwt worktree; use `--detach` (or `-d`) to create the session without attaching so you can continue working in your current terminal
 - `gwt switch feature-branch` – reattach to the tmux session
 - `gwt list` – list worktrees plus matching tmux sessions
 - `gwt remove feature-branch` – remove the worktree and tmux session after the branch is merged

--- a/bin/gwt
+++ b/bin/gwt
@@ -414,7 +414,7 @@ configure_tmux_session() {
     local hook_script
     hook_script="$(get_hook_script_path "new")"
     if [[ -n "$hook_script" ]]; then
-        tmux send-keys -t "$session:0.1" "$hook_script" C-m
+        tmux send-keys -t "$session:0.1" "source $hook_script" C-m
     fi
 
     attach_tmux_session "$session"
@@ -599,8 +599,15 @@ cmd_remove() {
     local hook_script
     hook_script="$(get_hook_script_path "remove")"
     if [[ -n "$hook_script" && -d "$worktree_dir" ]]; then
-        echo "→ running remove hook"
-        (cd "$worktree_dir" && "$hook_script")
+        if tmux has-session -t "$session" 2>/dev/null; then
+            echo "→ running remove hook in tmux pane"
+            local wait_channel="gwt-remove-$$"
+            tmux send-keys -t "$session:0.1" "source $hook_script; tmux wait-for -S $wait_channel" C-m
+            tmux wait-for "$wait_channel"
+        else
+            echo "→ running remove hook"
+            (cd "$worktree_dir" && "$hook_script")
+        fi
     fi
     tmux kill-session -t "$session" 2>/dev/null || true
     git worktree remove "$worktree_dir" --force

--- a/bin/gwt
+++ b/bin/gwt
@@ -383,6 +383,7 @@ configure_tmux_session() {
     tmux set-option -t "$session" @gwt_agent_worktree "$worktree_dir"
     tmux set-option -t "$session" @gwt_agent_command "$agent_command"
     tmux set-option -t "$session" @gwt_agent_exit_code ""
+    tmux set-option -t "$session" @gwt_agent_pid ""
 
     if [[ -n "$agent_command" ]]; then
         tmux set-option -t "$session" @gwt_agent_status "waiting"
@@ -1048,6 +1049,7 @@ cmd_completion() {
 infer_agent_status() {
     local session="$1"
     local agent_command="$2"
+    local agent_pid="$3"
     local pane="${session}:0.0"
     local dead=""
     dead="$(tmux display-message -p -t "$pane" "#{pane_dead}" 2>/dev/null || true)"
@@ -1058,6 +1060,24 @@ infer_agent_status() {
     local expect_agent=0
     if [[ -n "${agent_command// }" ]]; then
         expect_agent=1
+    fi
+    if [[ -n "${agent_pid// }" ]]; then
+        local stat
+        stat="$(ps -o stat= -p "$agent_pid" 2>/dev/null | awk 'NR==1 {gsub(/^[ \t]+|[ \t]+$/, ""); print}')"
+        if [[ -z "$stat" || "$stat" == *Z* ]]; then
+            echo "done"
+            return
+        fi
+        if [[ "$stat" == *R* || "$stat" == *D* ]]; then
+            echo "running"
+            return
+        fi
+        if [[ "$stat" == *T* ]]; then
+            echo "waiting"
+            return
+        fi
+        echo "waiting"
+        return
     fi
     if [[ "$dead" == "1" ]]; then
         echo "done"
@@ -1119,6 +1139,7 @@ cmd_agent_status() {
         local status="missing"
         local agent_command=""
         local exit_code=""
+        local agent_pid=""
         if tmux has-session -t "$session" 2>/dev/null; then
             local raw_command=""
             raw_command="$(tmux show-option -t "$session" -v @gwt_agent_command 2>/dev/null || true)"
@@ -1127,9 +1148,11 @@ cmd_agent_status() {
             status="${status//$'\n'/}"
             exit_code="$(tmux show-option -t "$session" -v @gwt_agent_exit_code 2>/dev/null || true)"
             exit_code="${exit_code//$'\n'/}"
+            agent_pid="$(tmux show-option -t "$session" -v @gwt_agent_pid 2>/dev/null || true)"
+            agent_pid="${agent_pid//$'\n'/}"
             local inferred_status
-            inferred_status="$(infer_agent_status "$session" "$agent_command")"
-            if [[ -z "$status" || "$status" == "disabled" ]]; then
+            inferred_status="$(infer_agent_status "$session" "$agent_command" "$agent_pid")"
+            if [[ -z "$status" || ( "$status" == "disabled" && -n "${agent_command// }" ) ]]; then
                 status="$inferred_status"
             fi
             if [[ "$status" == "error" && -n "$exit_code" ]]; then
@@ -1141,6 +1164,13 @@ cmd_agent_status() {
         fi
         local agent_display="$agent_command"
         if [[ -z "${agent_display// }" ]]; then
+            if [[ -n "${agent_pid// }" ]]; then
+                local ps_command
+                ps_command="$(ps -o comm= -p "$agent_pid" 2>/dev/null | awk 'NR==1 {print}')"
+                if [[ -n "$ps_command" ]]; then
+                    agent_display="$ps_command"
+                fi
+            fi
             if tmux has-session -t "$session" 2>/dev/null; then
                 local pane_command=""
                 pane_command="$(tmux display-message -p -t "${session}:0.0" "#{pane_current_command}" 2>/dev/null || true)"
@@ -1175,14 +1205,22 @@ cmd_agent_run_internal() {
     if [[ -z "${agent_command// }" ]]; then
         tmux set-option -t "$session" @gwt_agent_status "disabled"
         tmux set-option -t "$session" @gwt_agent_exit_code ""
+        tmux set-option -t "$session" @gwt_agent_pid ""
         return 0
     fi
     tmux set-option -t "$session" @gwt_agent_status "running"
     tmux set-option -t "$session" @gwt_agent_exit_code ""
+    tmux set-option -t "$session" @gwt_agent_pid ""
     set +e
-    eval "$raw_command"
+    eval "$raw_command" &
+    local agent_pid=$!
+    if [[ -n "$agent_pid" ]]; then
+        tmux set-option -t "$session" @gwt_agent_pid "$agent_pid"
+    fi
+    wait "$agent_pid"
     local exit_code=$?
     set -e
+    tmux set-option -t "$session" @gwt_agent_pid ""
     if [[ $exit_code -eq 0 ]]; then
         tmux set-option -t "$session" @gwt_agent_status "done"
     else

--- a/bin/gwt
+++ b/bin/gwt
@@ -58,6 +58,7 @@ Tmux integration
 
 Agent configuration
   agent show              Show current agent command
+  agent status            Show agent pane status for each worktree
   agent set <command>     Update the command used to start the agent pane
   agent clear             Remove the agent command
 
@@ -369,6 +370,7 @@ configure_tmux_session() {
 
     tmux rename-window -t "$session:0" "workspace"
     tmux split-window -t "$session:0" -h -c "$worktree_dir"
+    tmux set-option -t "$session:0" remain-on-exit on
 
     local agent_command=""
     if [[ "$agent_override_set" -eq 1 ]]; then
@@ -377,9 +379,19 @@ configure_tmux_session() {
         agent_command="${GWT_AGENT_COMMAND:-}"
     fi
 
+    tmux set-option -t "$session" @gwt_agent_branch "$branch"
+    tmux set-option -t "$session" @gwt_agent_worktree "$worktree_dir"
+    tmux set-option -t "$session" @gwt_agent_command "$agent_command"
+    tmux set-option -t "$session" @gwt_agent_exit_code ""
+
     if [[ -n "$agent_command" ]]; then
-        tmux send-keys -t "$session:0.0" "$agent_command" C-m
+        tmux set-option -t "$session" @gwt_agent_status "waiting"
+        local escaped_session
+        escaped_session=$(printf '%q' "$session")
+        tmux send-keys -t "$session:0.0" "gwt __agent-run $escaped_session" C-m
         tmux select-pane -t "$session:0.0"
+    else
+        tmux set-option -t "$session" @gwt_agent_status "disabled"
     fi
     tmux send-keys -t "$session:0.1" "git status" C-m
 
@@ -869,7 +881,7 @@ _gwt_completion() {
             ;;
         agent)
             if (( COMP_CWORD == 2 )); then
-                COMPREPLY=( $(compgen -W "show set clear" -- "$cur") )
+                COMPREPLY=( $(compgen -W "show status set clear" -- "$cur") )
             fi
             ;;
         completion)
@@ -986,6 +998,7 @@ _gwt() {
                 local -a actions
                 actions=(
                     'show:Print the configured agent command'
+                    'status:Show agent pane status'
                     'set:Set the agent command'
                     'clear:Remove the agent command'
                 )
@@ -1030,6 +1043,153 @@ cmd_completion() {
             exit 1
             ;;
     esac
+}
+
+infer_agent_status() {
+    local session="$1"
+    local agent_command="$2"
+    local pane="${session}:0.0"
+    local dead=""
+    dead="$(tmux display-message -p -t "$pane" "#{pane_dead}" 2>/dev/null || true)"
+    dead="${dead//$'\n'/}"
+    local current_command=""
+    current_command="$(tmux display-message -p -t "$pane" "#{pane_current_command}" 2>/dev/null || true)"
+    current_command="${current_command//$'\n'/}"
+    local expect_agent=0
+    if [[ -n "${agent_command// }" ]]; then
+        expect_agent=1
+    fi
+    if [[ "$dead" == "1" ]]; then
+        echo "done"
+        return
+    fi
+    if [[ -z "$current_command" ]]; then
+        if (( expect_agent )); then
+            echo "waiting"
+        else
+            echo "unknown"
+        fi
+        return
+    fi
+    case "$current_command" in
+        ""|bash|-bash|zsh|-zsh|sh|-sh|fish|dash)
+            if (( expect_agent )); then
+                echo "waiting"
+            else
+                echo "disabled"
+            fi
+            ;;
+        *)
+            echo "running"
+            ;;
+    esac
+}
+
+cmd_agent_status() {
+    require_git_repo
+    require_command tmux
+    local -a branches=()
+    while IFS= read -r line; do
+        case "$line" in
+            "worktree "*)
+                ;;
+            "branch "*)
+                local branch="${line#branch }"
+                branch="${branch#refs/heads/}"
+                if [[ -n "$branch" ]]; then
+                    branches+=("$branch")
+                fi
+                ;;
+        esac
+    done < <(git worktree list --porcelain)
+
+    if [[ ${#branches[@]} -eq 0 ]]; then
+        echo "gwt: no worktrees found" >&2
+        exit 1
+    fi
+
+    printf '%-25s %-16s %-20s %s\n' "Branch" "Status" "Session" "Agent"
+    printf '%-25s %-16s %-20s %s\n' "------" "------" "-------" "-----"
+
+    local idx
+    for idx in "${!branches[@]}"; do
+        local branch="${branches[$idx]}"
+        local session
+        session="$(session_name_for_branch "$branch")"
+        local status="missing"
+        local agent_command=""
+        local exit_code=""
+        if tmux has-session -t "$session" 2>/dev/null; then
+            local raw_command=""
+            raw_command="$(tmux show-option -t "$session" -v @gwt_agent_command 2>/dev/null || true)"
+            agent_command="${raw_command//$'\n'/ }"
+            status="$(tmux show-option -t "$session" -v @gwt_agent_status 2>/dev/null || true)"
+            status="${status//$'\n'/}"
+            exit_code="$(tmux show-option -t "$session" -v @gwt_agent_exit_code 2>/dev/null || true)"
+            exit_code="${exit_code//$'\n'/}"
+            local inferred_status
+            inferred_status="$(infer_agent_status "$session" "$agent_command")"
+            if [[ -z "$status" || "$status" == "disabled" ]]; then
+                status="$inferred_status"
+            fi
+            if [[ "$status" == "error" && -n "$exit_code" ]]; then
+                status+=" (exit ${exit_code})"
+            fi
+            if [[ -z "$status" ]]; then
+                status="unknown"
+            fi
+        fi
+        local agent_display="$agent_command"
+        if [[ -z "${agent_display// }" ]]; then
+            if tmux has-session -t "$session" 2>/dev/null; then
+                local pane_command=""
+                pane_command="$(tmux display-message -p -t "${session}:0.0" "#{pane_current_command}" 2>/dev/null || true)"
+                pane_command="${pane_command//$'\n'/}"
+                case "$pane_command" in
+                    ""|bash|-bash|zsh|-zsh|sh|-sh|fish|dash)
+                        ;;
+                    *)
+                        agent_display="$pane_command"
+                        ;;
+                esac
+            fi
+        fi
+        if [[ -z "${agent_display// }" ]]; then
+            agent_display="-"
+        fi
+        printf '%-25s %-16s %-20s %s\n' "$branch" "$status" "$session" "$agent_display"
+    done
+}
+
+cmd_agent_run_internal() {
+    local session="${1:-}"
+    if [[ -z "$session" ]]; then
+        echo "Usage: gwt __agent-run <session>" >&2
+        exit 1
+    fi
+    require_command tmux
+    local agent_command=""
+    local raw_command=""
+    raw_command="$(tmux show-option -t "$session" -v @gwt_agent_command 2>/dev/null || true)"
+    agent_command="${raw_command//$'\n'/ }"
+    if [[ -z "${agent_command// }" ]]; then
+        tmux set-option -t "$session" @gwt_agent_status "disabled"
+        tmux set-option -t "$session" @gwt_agent_exit_code ""
+        return 0
+    fi
+    tmux set-option -t "$session" @gwt_agent_status "running"
+    tmux set-option -t "$session" @gwt_agent_exit_code ""
+    set +e
+    eval "$raw_command"
+    local exit_code=$?
+    set -e
+    if [[ $exit_code -eq 0 ]]; then
+        tmux set-option -t "$session" @gwt_agent_status "done"
+    else
+        tmux set-option -t "$session" @gwt_agent_status "error"
+        tmux set-option -t "$session" @gwt_agent_exit_code "$exit_code"
+    fi
+    return "$exit_code"
 }
 
 cmd_agent_show() {
@@ -1081,15 +1241,17 @@ main() {
             local sub="${1:-}"; shift || true
             case "$sub" in
                 show) cmd_agent_show ;;
+                status) cmd_agent_status ;;
                 set) cmd_agent_set "$@" ;;
                 clear) cmd_agent_clear ;;
-                *) echo "Usage: gwt agent {show|set|clear}" >&2; exit 1 ;;
+                *) echo "Usage: gwt agent {show|status|set|clear}" >&2; exit 1 ;;
             esac
             ;;
         completion) cmd_completion "$@" ;;
         config-path) cmd_config_path ;;
         version|--version|-v|-V) cmd_version ;;
         help|-h|--help) print_usage ;;
+        __agent-run) cmd_agent_run_internal "$@" ;;
         *) echo "Unknown command: $cmd" >&2; print_usage; exit 1 ;;
     esac
 }

--- a/bin/gwt
+++ b/bin/gwt
@@ -44,6 +44,7 @@ Usage: gwt <command> [args]
 Core commands
   new <branch> [base]     Create a worktree + tmux session (base defaults to main)
                           Use --agent CMD or --no-agent to override the agent pane
+                          Use --detach or -d to create without attaching
   switch <branch>         Attach to an existing session
   list                    List worktrees and matching tmux sessions
   remove <branch>         Remove worktree, tmux session, and local branch
@@ -392,6 +393,7 @@ configure_tmux_session() {
     local branch="$1"
     local agent_override="${2:-}"
     local agent_override_set="${3:-0}"
+    local detach="${4:-0}"
     local worktree_dir
     worktree_dir="$(worktree_path_for_branch "$branch")"
     local session
@@ -418,7 +420,11 @@ configure_tmux_session() {
         tmux send-keys -t "$session:0.1" "source $hook_script" C-m
     fi
 
-    attach_tmux_session "$session"
+    if (( detach )); then
+        echo "✓ created session $session (use 'gwt switch $branch' to attach)"
+    else
+        attach_tmux_session "$session"
+    fi
 }
 
 configure_tmux_session_recovery() {
@@ -443,6 +449,7 @@ cmd_new() {
     local base_branch=""
     local agent_override=""
     local agent_override_set=0
+    local detach=0
     local positionals=()
 
     while [[ $# -gt 0 ]]; do
@@ -466,6 +473,10 @@ cmd_new() {
                 agent_override_set=1
                 shift
                 ;;
+            --detach|-d)
+                detach=1
+                shift
+                ;;
             --)
                 shift
                 positionals+=("$@")
@@ -483,7 +494,7 @@ cmd_new() {
     done
 
     if [[ ${#positionals[@]} -lt 1 ]]; then
-        echo "Usage: gwt new <branch> [base] [--agent CMD | --no-agent]" >&2
+        echo "Usage: gwt new <branch> [base] [--agent CMD | --no-agent] [--detach]" >&2
         exit 1
     fi
 
@@ -520,7 +531,7 @@ cmd_new() {
 
     create_worktree "$branch" "$base_branch"
     update_workspace_for_branch add "$branch"
-    configure_tmux_session "$branch" "$agent_override" "$agent_override_set"
+    configure_tmux_session "$branch" "$agent_override" "$agent_override_set" "$detach"
 }
 
 cmd_switch() {
@@ -1010,7 +1021,7 @@ _gwt_completion() {
         new)
             local prev="${COMP_WORDS[COMP_CWORD-1]}"
             if [[ "$cur" == -* ]]; then
-                COMPREPLY=( $(compgen -W "--agent --no-agent" -- "$cur") )
+                COMPREPLY=( $(compgen -W "--agent --no-agent --detach -d" -- "$cur") )
                 return
             fi
             if [[ "$prev" == "--agent" ]]; then
@@ -1139,6 +1150,8 @@ _gwt() {
                 new_opts=(
                     '--agent:Set command to run in agent pane'
                     '--no-agent:Do not start an agent pane'
+                    '--detach:Create session without attaching'
+                    '-d:Create session without attaching'
                 )
                 _describe 'option' new_opts
                 return

--- a/bin/gwt
+++ b/bin/gwt
@@ -58,7 +58,6 @@ Tmux integration
 
 Agent configuration
   agent show              Show current agent command
-  agent status            Show agent pane status for each worktree
   agent set <command>     Update the command used to start the agent pane
   agent clear             Remove the agent command
 
@@ -210,6 +209,16 @@ copy_env_if_present() {
     local worktree_dir="$1"
     if [[ -f "$root/.env" ]]; then
         cp "$root/.env" "$worktree_dir/.env"
+    fi
+}
+
+get_hook_script_path() {
+    local hook_name="$1"
+    local root
+    root="$(canonical_repo_root)"
+    local script_path="$root/.geewit_${hook_name}.sh"
+    if [[ -f "$script_path" && -x "$script_path" ]]; then
+        echo "$script_path"
     fi
 }
 
@@ -396,22 +405,17 @@ configure_tmux_session() {
         agent_command="${GWT_AGENT_COMMAND:-}"
     fi
 
-    tmux set-option -t "$session" @gwt_agent_branch "$branch"
-    tmux set-option -t "$session" @gwt_agent_worktree "$worktree_dir"
-    tmux set-option -t "$session" @gwt_agent_command "$agent_command"
-    tmux set-option -t "$session" @gwt_agent_exit_code ""
-    tmux set-option -t "$session" @gwt_agent_pid ""
-
     if [[ -n "$agent_command" ]]; then
-        tmux set-option -t "$session" @gwt_agent_status "waiting"
-        local escaped_session
-        escaped_session=$(printf '%q' "$session")
-        tmux send-keys -t "$session:0.0" "gwt __agent-run $escaped_session" C-m
+        tmux send-keys -t "$session:0.0" "$agent_command" C-m
         tmux select-pane -t "$session:0.0"
-    else
-        tmux set-option -t "$session" @gwt_agent_status "disabled"
     fi
     tmux send-keys -t "$session:0.1" "git status" C-m
+
+    local hook_script
+    hook_script="$(get_hook_script_path "new")"
+    if [[ -n "$hook_script" ]]; then
+        tmux send-keys -t "$session:0.1" "$hook_script" C-m
+    fi
 
     attach_tmux_session "$session"
 }
@@ -591,6 +595,12 @@ cmd_remove() {
     if [[ ! "$reply" =~ ^[Yy]$ ]]; then
         echo "aborted"
         exit 1
+    fi
+    local hook_script
+    hook_script="$(get_hook_script_path "remove")"
+    if [[ -n "$hook_script" && -d "$worktree_dir" ]]; then
+        echo "→ running remove hook"
+        (cd "$worktree_dir" && "$hook_script")
     fi
     tmux kill-session -t "$session" 2>/dev/null || true
     git worktree remove "$worktree_dir" --force
@@ -952,7 +962,7 @@ _gwt_completion() {
             ;;
         agent)
             if (( COMP_CWORD == 2 )); then
-                COMPREPLY=( $(compgen -W "show status set clear" -- "$cur") )
+                COMPREPLY=( $(compgen -W "show set clear" -- "$cur") )
             fi
             ;;
         completion)
@@ -1069,7 +1079,6 @@ _gwt() {
                 local -a actions
                 actions=(
                     'show:Print the configured agent command'
-                    'status:Show agent pane status'
                     'set:Set the agent command'
                     'clear:Remove the agent command'
                 )
@@ -1114,190 +1123,6 @@ cmd_completion() {
             exit 1
             ;;
     esac
-}
-
-infer_agent_status() {
-    local session="$1"
-    local agent_command="$2"
-    local agent_pid="$3"
-    local pane="${session}:0.0"
-    local dead=""
-    dead="$(tmux display-message -p -t "$pane" "#{pane_dead}" 2>/dev/null || true)"
-    dead="${dead//$'\n'/}"
-    local current_command=""
-    current_command="$(tmux display-message -p -t "$pane" "#{pane_current_command}" 2>/dev/null || true)"
-    current_command="${current_command//$'\n'/}"
-    local expect_agent=0
-    if [[ -n "${agent_command// }" ]]; then
-        expect_agent=1
-    fi
-    if [[ -n "${agent_pid// }" ]]; then
-        local stat
-        stat="$(ps -o stat= -p "$agent_pid" 2>/dev/null | awk 'NR==1 {gsub(/^[ \t]+|[ \t]+$/, ""); print}')"
-        if [[ -z "$stat" || "$stat" == *Z* ]]; then
-            echo "done"
-            return
-        fi
-        if [[ "$stat" == *R* || "$stat" == *D* ]]; then
-            echo "running"
-            return
-        fi
-        if [[ "$stat" == *T* ]]; then
-            echo "waiting"
-            return
-        fi
-        echo "waiting"
-        return
-    fi
-    if [[ "$dead" == "1" ]]; then
-        echo "done"
-        return
-    fi
-    if [[ -z "$current_command" ]]; then
-        if (( expect_agent )); then
-            echo "waiting"
-        else
-            echo "unknown"
-        fi
-        return
-    fi
-    case "$current_command" in
-        ""|bash|-bash|zsh|-zsh|sh|-sh|fish|dash)
-            if (( expect_agent )); then
-                echo "waiting"
-            else
-                echo "disabled"
-            fi
-            ;;
-        *)
-            echo "running"
-            ;;
-    esac
-}
-
-cmd_agent_status() {
-    require_git_repo
-    require_command tmux
-    local -a branches=()
-    while IFS= read -r line; do
-        case "$line" in
-            "worktree "*)
-                ;;
-            "branch "*)
-                local branch="${line#branch }"
-                branch="${branch#refs/heads/}"
-                if [[ -n "$branch" ]]; then
-                    branches+=("$branch")
-                fi
-                ;;
-        esac
-    done < <(git worktree list --porcelain)
-
-    if [[ ${#branches[@]} -eq 0 ]]; then
-        echo "gwt: no worktrees found" >&2
-        exit 1
-    fi
-
-    printf '%-25s %-16s %-20s %s\n' "Branch" "Status" "Session" "Agent"
-    printf '%-25s %-16s %-20s %s\n' "------" "------" "-------" "-----"
-
-    local idx
-    for idx in "${!branches[@]}"; do
-        local branch="${branches[$idx]}"
-        local session
-        session="$(session_name_for_branch "$branch")"
-        local status="missing"
-        local agent_command=""
-        local exit_code=""
-        local agent_pid=""
-        if tmux has-session -t "$session" 2>/dev/null; then
-            local raw_command=""
-            raw_command="$(tmux show-option -t "$session" -v @gwt_agent_command 2>/dev/null || true)"
-            agent_command="${raw_command//$'\n'/ }"
-            status="$(tmux show-option -t "$session" -v @gwt_agent_status 2>/dev/null || true)"
-            status="${status//$'\n'/}"
-            exit_code="$(tmux show-option -t "$session" -v @gwt_agent_exit_code 2>/dev/null || true)"
-            exit_code="${exit_code//$'\n'/}"
-            agent_pid="$(tmux show-option -t "$session" -v @gwt_agent_pid 2>/dev/null || true)"
-            agent_pid="${agent_pid//$'\n'/}"
-            local inferred_status
-            inferred_status="$(infer_agent_status "$session" "$agent_command" "$agent_pid")"
-            if [[ -z "$status" || ( "$status" == "disabled" && -n "${agent_command// }" ) ]]; then
-                status="$inferred_status"
-            fi
-            if [[ "$status" == "error" && -n "$exit_code" ]]; then
-                status+=" (exit ${exit_code})"
-            fi
-            if [[ -z "$status" ]]; then
-                status="unknown"
-            fi
-        fi
-        local agent_display="$agent_command"
-        if [[ -z "${agent_display// }" ]]; then
-            if [[ -n "${agent_pid// }" ]]; then
-                local ps_command
-                ps_command="$(ps -o comm= -p "$agent_pid" 2>/dev/null | awk 'NR==1 {print}')"
-                if [[ -n "$ps_command" ]]; then
-                    agent_display="$ps_command"
-                fi
-            fi
-            if tmux has-session -t "$session" 2>/dev/null; then
-                local pane_command=""
-                pane_command="$(tmux display-message -p -t "${session}:0.0" "#{pane_current_command}" 2>/dev/null || true)"
-                pane_command="${pane_command//$'\n'/}"
-                case "$pane_command" in
-                    ""|bash|-bash|zsh|-zsh|sh|-sh|fish|dash)
-                        ;;
-                    *)
-                        agent_display="$pane_command"
-                        ;;
-                esac
-            fi
-        fi
-        if [[ -z "${agent_display// }" ]]; then
-            agent_display="-"
-        fi
-        printf '%-25s %-16s %-20s %s\n' "$branch" "$status" "$session" "$agent_display"
-    done
-}
-
-cmd_agent_run_internal() {
-    local session="${1:-}"
-    if [[ -z "$session" ]]; then
-        echo "Usage: gwt __agent-run <session>" >&2
-        exit 1
-    fi
-    require_command tmux
-    local agent_command=""
-    local raw_command=""
-    raw_command="$(tmux show-option -t "$session" -v @gwt_agent_command 2>/dev/null || true)"
-    agent_command="${raw_command//$'\n'/ }"
-    if [[ -z "${agent_command// }" ]]; then
-        tmux set-option -t "$session" @gwt_agent_status "disabled"
-        tmux set-option -t "$session" @gwt_agent_exit_code ""
-        tmux set-option -t "$session" @gwt_agent_pid ""
-        return 0
-    fi
-    tmux set-option -t "$session" @gwt_agent_status "running"
-    tmux set-option -t "$session" @gwt_agent_exit_code ""
-    tmux set-option -t "$session" @gwt_agent_pid ""
-    set +e
-    eval "$raw_command" &
-    local agent_pid=$!
-    if [[ -n "$agent_pid" ]]; then
-        tmux set-option -t "$session" @gwt_agent_pid "$agent_pid"
-    fi
-    wait "$agent_pid"
-    local exit_code=$?
-    set -e
-    tmux set-option -t "$session" @gwt_agent_pid ""
-    if [[ $exit_code -eq 0 ]]; then
-        tmux set-option -t "$session" @gwt_agent_status "done"
-    else
-        tmux set-option -t "$session" @gwt_agent_status "error"
-        tmux set-option -t "$session" @gwt_agent_exit_code "$exit_code"
-    fi
-    return "$exit_code"
 }
 
 cmd_agent_show() {
@@ -1349,17 +1174,15 @@ main() {
             local sub="${1:-}"; shift || true
             case "$sub" in
                 show) cmd_agent_show ;;
-                status) cmd_agent_status ;;
                 set) cmd_agent_set "$@" ;;
                 clear) cmd_agent_clear ;;
-                *) echo "Usage: gwt agent {show|status|set|clear}" >&2; exit 1 ;;
+                *) echo "Usage: gwt agent {show|set|clear}" >&2; exit 1 ;;
             esac
             ;;
         completion) cmd_completion "$@" ;;
         config-path) cmd_config_path ;;
         version|--version|-v|-V) cmd_version ;;
         help|-h|--help) print_usage ;;
-        __agent-run) cmd_agent_run_internal "$@" ;;
         *) echo "Unknown command: $cmd" >&2; print_usage; exit 1 ;;
     esac
 }

--- a/bin/gwt
+++ b/bin/gwt
@@ -46,7 +46,8 @@ Core commands
                           Use --agent CMD or --no-agent to override the agent pane
   switch <branch>         Attach to an existing session
   list                    List worktrees and matching tmux sessions
-  remove <branch>         Remove worktree and tmux session
+  remove <branch>         Remove worktree, tmux session, and local branch
+                          Use --keep-branch to preserve the local branch
   cleanup [base]          Remove worktrees already merged into base (default: main)
   merge <branch> [base]   Merge branch into base and clean up the worktree
   status                  Show git status for every worktree
@@ -582,15 +583,46 @@ cmd_list() {
 cmd_remove() {
     require_git_repo
     require_command tmux
-    local branch="${1:-}"
+    local branch=""
+    local keep_branch=0
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --keep-branch)
+                keep_branch=1
+                shift
+                ;;
+            --)
+                shift
+                if [[ $# -gt 0 ]]; then
+                    branch="$1"
+                fi
+                break
+                ;;
+            --*)
+                echo "gwt remove: unknown option '$1'" >&2
+                exit 1
+                ;;
+            *)
+                branch="$1"
+                shift
+                ;;
+        esac
+    done
+
     if [[ -z "$branch" ]]; then
-        echo "Usage: gwt remove <branch>" >&2
+        echo "Usage: gwt remove <branch> [--keep-branch]" >&2
         exit 1
     fi
     local worktree_dir session
     worktree_dir="$(worktree_path_for_branch "$branch")"
     session="$(session_name_for_branch "$branch")"
-    echo "This will remove $worktree_dir and tmux session $session"
+    local repo_dir
+    repo_dir="$(canonical_repo_root)"
+    echo "This will remove $worktree_dir, tmux session $session, and local branch $branch"
+    if (( keep_branch )); then
+        echo "(--keep-branch: local branch will be preserved)"
+    fi
     read -r -p "Continue? [y/N] " reply
     if [[ ! "$reply" =~ ^[Yy]$ ]]; then
         echo "aborted"
@@ -612,7 +644,17 @@ cmd_remove() {
     tmux kill-session -t "$session" 2>/dev/null || true
     git worktree remove "$worktree_dir" --force
     update_workspace_for_branch remove "$branch"
-    echo "✓ removed $branch"
+    if (( keep_branch )); then
+        echo "✓ removed worktree and session for $branch (branch preserved)"
+    else
+        if git -C "$repo_dir" branch -d "$branch" 2>/dev/null; then
+            echo "✓ removed $branch"
+        elif git -C "$repo_dir" branch -D "$branch" 2>/dev/null; then
+            echo "✓ removed $branch (force deleted unmerged branch)"
+        else
+            echo "✓ removed worktree and session (branch $branch not found or could not be deleted)"
+        fi
+    fi
 }
 
 cmd_cleanup() {
@@ -912,7 +954,18 @@ _gwt_completion() {
     fi
 
     case "$cmd" in
-        switch|remove)
+        switch)
+            local branches
+            branches=$(_gwt_branch_worktrees)
+            if [[ -n "$branches" ]]; then
+                COMPREPLY=( $(compgen -W "$branches" -- "$cur") )
+            fi
+            ;;
+        remove)
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=( $(compgen -W "--keep-branch" -- "$cur") )
+                return
+            fi
             local branches
             branches=$(_gwt_branch_worktrees)
             if [[ -n "$branches" ]]; then
@@ -1023,7 +1076,21 @@ _gwt() {
 
     local cmd=${words[2]}
     case $cmd in
-        switch|remove)
+        switch)
+            local -a branches
+            branches=(${(f)"$(_gwt_branch_worktrees)"})
+            _describe 'branch' branches
+            ;;
+        remove)
+            local current_arg=${words[CURRENT]}
+            if [[ $current_arg == -* ]]; then
+                local -a remove_opts
+                remove_opts=(
+                    '--keep-branch:Preserve the local git branch'
+                )
+                _describe 'option' remove_opts
+                return
+            fi
             local -a branches
             branches=(${(f)"$(_gwt_branch_worktrees)"})
             _describe 'branch' branches

--- a/bin/gwt
+++ b/bin/gwt
@@ -633,8 +633,12 @@ cmd_remove() {
     if [[ -n "$hook_script" && -d "$worktree_dir" ]]; then
         if tmux has-session -t "$session" 2>/dev/null; then
             echo "→ running remove hook in tmux pane"
+            tmux send-keys -t "$session:0.1" C-c C-c
             local wait_channel="gwt-remove-$$"
-            tmux send-keys -t "$session:0.1" "source $hook_script; tmux wait-for -S $wait_channel" C-m
+            local hook_command
+            printf -v hook_command 'cd "%s" && ( source "%s" ) || true; tmux wait-for -S "%s"' \
+                "$worktree_dir" "$hook_script" "$wait_channel"
+            tmux send-keys -t "$session:0.1" "$hook_command" C-m
             tmux wait-for "$wait_channel"
         else
             echo "→ running remove hook"

--- a/bin/gwt
+++ b/bin/gwt
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+readonly GWT_VERSION="0.1.1"
+
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/gwt"
 CONFIG_FILE="${GWT_CONFIG_FILE:-$CONFIG_DIR/config}"
 
@@ -62,6 +64,7 @@ Agent configuration
 Other
   config-path             Print the config file location
   completion <shell>      Print shell completion script (bash|zsh)
+  version                 Show CLI version
   help                    Show this message
 EOS
 }
@@ -804,7 +807,7 @@ _gwt_completion() {
     local cmd="${COMP_WORDS[1]}"
 
     if (( COMP_CWORD == 1 )); then
-        COMPREPLY=( $(compgen -W "new switch list remove cleanup merge status push from-pr tmux-status agent config-path completion help" -- "$cur") )
+        COMPREPLY=( $(compgen -W "new switch list remove cleanup merge status push from-pr tmux-status agent config-path completion version help" -- "$cur") )
         return
     fi
 
@@ -909,6 +912,7 @@ _gwt() {
         'agent:Manage agent command'
         'config-path:Show config file path'
         'completion:Print completion script'
+        'version:Show CLI version'
         'help:Show usage'
     )
 
@@ -1053,6 +1057,10 @@ cmd_config_path() {
     echo "$CONFIG_FILE"
 }
 
+cmd_version() {
+    echo "gwt $GWT_VERSION"
+}
+
 main() {
     load_config
     ensure_config_dir
@@ -1080,6 +1088,7 @@ main() {
             ;;
         completion) cmd_completion "$@" ;;
         config-path) cmd_config_path ;;
+        version|--version|-v|-V) cmd_version ;;
         help|-h|--help) print_usage ;;
         *) echo "Unknown command: $cmd" >&2; print_usage; exit 1 ;;
     esac

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$SCRIPT_DIR"
 PREFIX="${PREFIX:-$HOME/.local}"
-AGENT_COMMAND=""
+AGENT_COMMAND="claude --dangerously-skip-permissions"
 WORKTREE_BASE=""
 DIR_PREFIX=""
 FORCE=0
@@ -18,7 +18,7 @@ Usage: ./install.sh [options]
 
 Options
   --prefix DIR          Install path prefix (default: ~/.local)
-  --agent CMD           Command to start in the agent pane (quoted if it has spaces)
+  --agent CMD           Command to start in the agent pane (default: claude --dangerously-skip-permissions)
   --worktree-base PATH  Default location for new worktrees (relative paths are resolved from the repo root)
   --dir-prefix STR      Prefix to add to generated worktree directory names
   --force               Overwrite existing gwt binary without prompting
@@ -127,8 +127,11 @@ write_config() {
     local value="$2"
     local escaped
     escaped=$(printf '%q' "$value")
+    local escaped_sed
+    escaped_sed="${escaped//\\/\\\\}"
+    escaped_sed="${escaped_sed//&/\\&}"
     if grep -q "^${key}=" "$CONFIG_FILE"; then
-        sed -i "s|^${key}=.*$|${key}=${escaped}|" "$CONFIG_FILE"
+        sed -i "s|^${key}=.*$|${key}=${escaped_sed}|" "$CONFIG_FILE"
     else
         printf '%s=%s\n' "$key" "$escaped" >> "$CONFIG_FILE"
     fi

--- a/install.sh
+++ b/install.sh
@@ -108,7 +108,16 @@ fi
 
 install -m 755 "$SOURCE_BIN" "$TARGET_BIN"
 
-echo "✓ installed to $TARGET_BIN"
+installed_version=""
+if installed_version="$("$TARGET_BIN" --version 2>/dev/null)"; then
+    if [[ -n "$installed_version" ]]; then
+        echo "✓ installed $installed_version to $TARGET_BIN"
+    else
+        echo "✓ installed to $TARGET_BIN"
+    fi
+else
+    echo "✓ installed to $TARGET_BIN"
+fi
 
 mkdir -p "$CONFIG_DIR"
 touch "$CONFIG_FILE"


### PR DESCRIPTION
## Summary

This PR adds several enhancements to geewit:

### New Features
- **Hook scripts support**: Run `.geewit_new.sh` after worktree setup and `.geewit_remove.sh` before cleanup. Scripts must be executable and live in the repo root.
- **`gwt agent status` command**: Display the status of agent panes for each worktree with detailed state reporting
- **Enhanced agent PID tracking**: Better monitoring of agent processes with exit code tracking
- **CLI version command**: Added `gwt version` / `gwt --version`

### Improvements
- Enhanced tmux integration for `gwt remove` - runs hook in tmux pane if session exists
- Updated default agent to "claude --dangerously-skip-permissions"
- Fixed config escaping for values with spaces
- Added CLAUDE.md to .gitignore

## Files Changed
- `bin/gwt` - Core functionality enhancements (+40 lines)
- `install.sh` - Installation improvements
- `README.md` - Documentation for new features
- `.gitignore` - Added CLAUDE.md exclusion

## Test Plan
- [ ] Test `gwt new` with a `.geewit_new.sh` hook script
- [ ] Test `gwt remove` with a `.geewit_remove.sh` hook script
- [ ] Test `gwt agent status` to view agent pane states
- [ ] Verify tmux session handling during remove operations